### PR TITLE
Small corrections on readme + change in sagemaker_us_guidance_network…

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,14 +105,7 @@ Only the following regions are supported for this guidance:
 * us-east-1
 * us-west-2
 * us-east-2
-* eu-central-1
-* sa-east-1
-* ap-northeast-2
-* eu-west-2
 * ap-northeast-1
-* ap-southeast-1
-* ap-southeast-2
-* ca-central-1
 
 Deploying the guidance in other regions may lead to errors or inconsistent behavior.
 
@@ -161,7 +154,6 @@ This user will be responsible to perform the following configuration steps:
 1. Select the `redshiftBaseCapacity` blueprint parameter and edit it order to change its value to 8. This change will set the RS serverless base capacity to 8 [RPUs](https://docs.aws.amazon.com/redshift/latest/mgmt/serverless-capacity.html) for all SageMaker Unified Studio projects allowing you to save on costs.
 1. Now you are ready to click on the `Open data portal` button at the top right corner of the page to access the SageMaker Unified Studio portal experience and continue with the [Data engineer](#data-engineer) steps.
 1. You will be redirected to the `Project list` section, create click on `Create Project` button and name it `SalesForecastingProject`. For the Project Profile select `Data Analytics and Al-ML Model Development` and click on `Continue`.
-1. On the second step of the project creation enter a unique name for the `SageMaker Unified Studio LakeHouse Catalog`, for example *sales-forecasting-catalog* (make sure you are lowercase letters, numbers, underscores and hyphens for the value of this field).
 1. Wait for the project to complete (this could take several minutes).
 1. Once the project is created you should be redirected to the project overview page. Now click on the `Members` section you have on the left menu and add the IAM Identity Center users you have created for your Data Engineer and ML Engineer personas (you can omit this step if you want to run all the guidance with the same IAM IC user).
 1. At the top center of the page you will find the _Project_ collapsible menu, expand the menu, select the `Compute` section and under the `Data Warehouse` tab make sure a *Redshift Serverless* compute is provisioned. You can provision more compute resources if needed for your project users at a later time.

--- a/deployment/sagemaker_us_guidance_network_setup.yaml
+++ b/deployment/sagemaker_us_guidance_network_setup.yaml
@@ -5,13 +5,24 @@ Description: >
   The template also creates a route from each private subnets to a NAT gateway with EIP in the public subnet, and a route in the public subnet to an IGW.
   This setup enables internet connectivity from SageMaker Unified Studio VPC which allows usage of all AWS services (SO9562).
 
+Parameters:
+  useVpcEndpoints:
+    Type: String
+    AllowedValues:
+      - true
+      - false
+    Default: false
+    Description: This controls whether VPC endpoints are created or not.
+
 Mappings:
+  # found with describe-vpc-endpoint-services --service-names com.amazonaws.<region>.redshift-serverless
+  # AZ IDs are fetched with aws ec2 describe-availability-zones --region <region> --query 'AvailabilityZones[*].[ZoneName, ZoneId]' --output text
   AvailabilityZonesId:
     eu-west-1:
       AZ1: euw1-az1
       AZ2: euw1-az2
       AZ3: euw1-az3
-      AZ4: ""  
+      AZ4: ""
     us-east-1:
       AZ1: use1-az1
       AZ2: use1-az2
@@ -34,13 +45,13 @@ Mappings:
       AZ4: ""
     sa-east-1:
       AZ1: sae1-az1
-      AZ2: sae1-az3
-      AZ3: ""
-      AZ4: ""  
+      AZ2: sae1-az2
+      AZ3: sae1-az3
+      AZ4: ""
     ap-northeast-2:
       AZ1: apne2-az1
-      AZ2: apne2-az3
-      AZ3: ""
+      AZ2: apne2-az2
+      AZ3: apne2-az3
       AZ4: ""
     eu-west-2:
       AZ1: euw2-az2
@@ -65,31 +76,47 @@ Mappings:
     ca-central-1:
       AZ1: cac1-az1
       AZ2: cac1-az2
-      AZ3: ""
+      AZ3: cac1-az4
       AZ4: ""
 
 Conditions:
+  useVpcEndpoints: !Equals [!Ref useVpcEndpoints, "true"]
+
   codeWhispererEnabledRegion: !Equals [!Ref "AWS::Region", 'us-east-1']
   qEnabledRegion: !Equals [!Ref "AWS::Region", 'us-east-1']
   isUSEast1: !Equals [!Ref "AWS::Region", 'us-east-1']
+  isSAEast1: !Equals [!Ref "AWS::Region", 'sa-east-1']
+  isCACentral1: !Equals [!Ref "AWS::Region", 'ca-central-1']
   
   hasAZ1ForRegion: !Not [!Equals [!FindInMap [AvailabilityZonesId, !Ref "AWS::Region", AZ1], ""]]
   hasAZ2ForRegion: !Not [!Equals [!FindInMap [AvailabilityZonesId, !Ref "AWS::Region", AZ2], ""]]
   hasAZ3ForRegion: !Not [!Equals [!FindInMap [AvailabilityZonesId, !Ref "AWS::Region", AZ3], ""]]
   hasAZ4ForRegion: !Not [!Equals [!FindInMap [AvailabilityZonesId, !Ref "AWS::Region", AZ4], ""]]
   
-  createVPCEWithTwoSubnets: !And [!Condition hasAZ1ForRegion, !Condition hasAZ2ForRegion, !Not [!Condition hasAZ3ForRegion]]
-  createVPCEWithThreeSubnets: !And [!Condition hasAZ1ForRegion, !Condition hasAZ2ForRegion, !Condition hasAZ3ForRegion]
+  createVPCEWithTwoSubnets: !And [!Condition useVpcEndpoints, !Condition hasAZ1ForRegion, !Condition hasAZ2ForRegion, !Not [!Condition hasAZ3ForRegion]]
+  createVPCEWithThreeSubnets: !And [!Condition useVpcEndpoints, !Condition hasAZ1ForRegion, !Condition hasAZ2ForRegion, !Condition hasAZ3ForRegion]
 
-  createVPCEWithTwoSubnetsRedshiftServerless: !And [!Condition hasAZ1ForRegion, !Condition hasAZ2ForRegion, !Not [!Condition hasAZ3ForRegion]]
-  createVPCEWithThreeSubnetsRedshiftServerlessNotUSEast1: !And [!Condition hasAZ1ForRegion, !Condition hasAZ2ForRegion, !Condition hasAZ3ForRegion, !Not [!Condition isUSEast1]]
-  createVPCEWithThreeSubnetsRedshiftServerlessUSEast1: !And [!Condition hasAZ1ForRegion, !Condition hasAZ2ForRegion, !Condition hasAZ4ForRegion, !Condition isUSEast1]
+  createVPCEWithTwoSubnetsRedshiftServerless: !And [!Condition useVpcEndpoints, !Condition hasAZ1ForRegion, !Condition hasAZ2ForRegion, !Not [!Condition hasAZ3ForRegion]]
+  createVPCEWithThreeSubnetsRedshiftServerlessNotUSEast1: !And [!Condition useVpcEndpoints, !Condition hasAZ1ForRegion, !Condition hasAZ2ForRegion, !Condition hasAZ3ForRegion, !Not [!Condition isUSEast1]]
+  createVPCEWithThreeSubnetsRedshiftServerlessUSEast1: !And [!Condition useVpcEndpoints, !Condition hasAZ1ForRegion, !Condition hasAZ2ForRegion, !Condition hasAZ4ForRegion, !Condition isUSEast1]
 
-  createVPCEWithTwoSubnetsCodeWhisperer: !And [!Condition codeWhispererEnabledRegion, !Condition createVPCEWithTwoSubnets]
-  createVPCEWithThreeSubnetsCodeWhisperer: !And [!Condition codeWhispererEnabledRegion, !Condition createVPCEWithThreeSubnets]
+  createVPCEWithTwoSubnetsCodeWhisperer: !And [!Condition useVpcEndpoints, !Condition codeWhispererEnabledRegion, !Condition createVPCEWithTwoSubnets]
+  createVPCEWithThreeSubnetsCodeWhisperer: !And [!Condition useVpcEndpoints, !Condition codeWhispererEnabledRegion, !Condition createVPCEWithThreeSubnets]
 
-  createVPCEWithTwoSubnetsQ: !And [!Condition qEnabledRegion, !Condition createVPCEWithTwoSubnets]
-  createVPCEWithThreeSubnetsQ: !And [!Condition qEnabledRegion, !Condition createVPCEWithThreeSubnets]
+  createVPCEWithTwoSubnetsQ: !And [!Condition useVpcEndpoints, !Condition qEnabledRegion, !Condition createVPCEWithTwoSubnets]
+  createVPCEWithThreeSubnetsQ: !And [!Condition useVpcEndpoints, !Condition qEnabledRegion, !Condition createVPCEWithThreeSubnets]
+
+  createVPCEWithTwoSubnetsCodeCommit: !And [!Condition useVpcEndpoints, !Condition isSAEast1]
+  createVPCEWithThreeSubnetsCodeCommit: !And [!Condition useVpcEndpoints, !Not [!Condition isSAEast1]]
+
+  createVPCEWithTwoSubnetsGitCodeCommit: !And [!Condition useVpcEndpoints, !Condition isSAEast1]
+  createVPCEWithThreeSubnetsGitCodeCommit: !And [!Condition useVpcEndpoints, !Not [!Condition isSAEast1]]
+
+  createVPCEWithTwoSubnetsEMR: !And [!Condition useVpcEndpoints, !Condition isCACentral1]
+  createVPCEWithThreeSubnetsEMR: !And [!Condition useVpcEndpoints, !Not [!Condition isCACentral1]]
+
+  createVPCEWithTwoSubnetsRedshift: !And [!Condition useVpcEndpoints, !Condition isCACentral1]
+  createVPCEWithThreeSubnetsRedshift: !And [!Condition useVpcEndpoints, !Not [!Condition isCACentral1]]
 
 Resources:
   SageMakerUnifiedStudioVpc:
@@ -381,7 +408,7 @@ Resources:
   # CodeCommit VPC-E
   ############################################################
   SageMakerUnifiedStudioCodeCommitVpcEndpointA:
-    Condition: createVPCEWithTwoSubnets
+    Condition: createVPCEWithTwoSubnetsCodeCommit
     Type: AWS::EC2::VPCEndpoint
     Properties:
       ServiceName: !Sub 'com.amazonaws.${AWS::Region}.codecommit'
@@ -392,10 +419,10 @@ Resources:
         - !Ref SageMakerUnifiedStudioSecurityGroup
       SubnetIds:
         - !Ref SageMakerUnifiedStudioPrivateSubnet1
-        - !Ref SageMakerUnifiedStudioPrivateSubnet2
+        - !Ref SageMakerUnifiedStudioPrivateSubnet3
   
   SageMakerUnifiedStudioCodeCommitVpcEndpointB:
-    Condition: createVPCEWithThreeSubnets
+    Condition: createVPCEWithThreeSubnetsCodeCommit
     Type: AWS::EC2::VPCEndpoint
     Properties:
       ServiceName: !Sub 'com.amazonaws.${AWS::Region}.codecommit'
@@ -413,7 +440,7 @@ Resources:
   # Git CodeCommit VPC-E
   ############################################################
   SageMakerUnifiedStudioGitCodeCommitVpcEndpointA:
-    Condition: createVPCEWithTwoSubnets
+    Condition: createVPCEWithTwoSubnetsGitCodeCommit
     Type: AWS::EC2::VPCEndpoint
     Properties:
       ServiceName: !Sub 'com.amazonaws.${AWS::Region}.git-codecommit'
@@ -424,10 +451,10 @@ Resources:
         - !Ref SageMakerUnifiedStudioSecurityGroup
       SubnetIds:
         - !Ref SageMakerUnifiedStudioPrivateSubnet1
-        - !Ref SageMakerUnifiedStudioPrivateSubnet2
+        - !Ref SageMakerUnifiedStudioPrivateSubnet3
 
   SageMakerUnifiedStudioGitCodeCommitVpcEndpointB:
-    Condition: createVPCEWithThreeSubnets
+    Condition: createVPCEWithThreeSubnetsGitCodeCommit
     Type: AWS::EC2::VPCEndpoint
     Properties:
       ServiceName: !Sub 'com.amazonaws.${AWS::Region}.git-codecommit'
@@ -664,7 +691,7 @@ Resources:
   # Redshift VPC-E
   ############################################################
   SageMakerUnifiedStudioRedshiftVpcEndpointA:
-    Condition: createVPCEWithTwoSubnets
+    Condition: createVPCEWithTwoSubnetsRedshift
     Type: AWS::EC2::VPCEndpoint
     Properties:
       ServiceName: !Sub 'com.amazonaws.${AWS::Region}.redshift'
@@ -678,7 +705,7 @@ Resources:
         - !Ref SageMakerUnifiedStudioPrivateSubnet2
 
   SageMakerUnifiedStudioRedshiftVpcEndpointB:
-    Condition: createVPCEWithThreeSubnets
+    Condition: createVPCEWithThreeSubnetsRedshift
     Type: AWS::EC2::VPCEndpoint
     Properties:
       ServiceName: !Sub 'com.amazonaws.${AWS::Region}.redshift'
@@ -984,7 +1011,7 @@ Resources:
   # EMR VPC-E
   ############################################################
   SageMakerUnifiedStudioEMRVpcEndpointA:
-    Condition: createVPCEWithTwoSubnets
+    Condition: createVPCEWithTwoSubnetsEMR
     Type: AWS::EC2::VPCEndpoint
     Properties:
       ServiceName: !Sub 'com.amazonaws.${AWS::Region}.elasticmapreduce'
@@ -998,7 +1025,7 @@ Resources:
         - !Ref SageMakerUnifiedStudioPrivateSubnet2
   
   SageMakerUnifiedStudioEMRVpcEndpointB:
-    Condition: createVPCEWithThreeSubnets
+    Condition: createVPCEWithThreeSubnetsEMR
     Type: AWS::EC2::VPCEndpoint
     Properties:
       ServiceName: !Sub 'com.amazonaws.${AWS::Region}.elasticmapreduce'


### PR DESCRIPTION
…_setup.yaml to provide option to opt out vpc endpoints

*Issue #, if available:* The Cloudformation template used to create the VPC used by SM Unified Studio was using VPC endpoints for all services, this causes on extra costs while not being strictly necessary (as the VPC is created with IGW. 

*Description of changes:* Changed template to include a flag to determine whether or not VPC endpoints should be created. Also updated readme accordingly.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
